### PR TITLE
Follow changes on RDFa Core 1.1 W3C Recommendation 07 June 2012

### DIFF
--- a/syntax/html/rdfa.vim
+++ b/syntax/html/rdfa.vim
@@ -1,11 +1,11 @@
 " Vim syntax file
-" Language:	    RDFa
-" Maintainer:	othree <othree@gmail.com>
-" URL:		    http://github.com/othree/html5-syntax.vim
-" Last Change:  2010-09-25
+" Language:     RDFa
+" Maintainer:   othree <othree@gmail.com>
+" URL:          http://github.com/othree/html5-syntax.vim
+" Last Change:  2012-06-08
 " License:      MIT
-" Changes:      update to Rec 14 October 2008
+" Changes:      update to Rec 07 June 2012
 
 " RDFa
-" http://www.w3.org/TR/rdfa-syntax/#a_xhtmlrdfa_dtd
-syn keyword htmlArg contained about typeof property resource content datatype rel rev 
+" http://www.w3.org/TR/rdfa-syntax/#s_syntax
+syn keyword htmlArg contained about content datatype href inlist prefix property rel resource rev src typeof vocab


### PR DESCRIPTION
RDF Core 1.1 has been published as W3C Recommendation: http://www.w3.org/TR/2012/REC-rdfa-core-20120607/
