### PR TITLE
Allow numbers in data attribute names

### DIFF
--- a/syntax/html.vim
+++ b/syntax/html.vim
@@ -83,7 +83,7 @@ syn keyword htmlArg contained srcset sizes
 
 " Custom Data Attributes
 " http://dev.w3.org/html5/spec/elements.html#embedding-custom-non-visible-data
-syn match   htmlArg "\<\(data\(\-[a-z]\+\)\+\)\=\>" contained
+syn match   htmlArg "\<\(data\(\-[a-z0-9]\+\)\+\)\=\>" contained
 
 " Microdata
 " http://dev.w3.org/html5/md/


### PR DESCRIPTION
I have to deal with data attributes of this form `data-foo4bar-baz` and this change highlights these attributes correctly.