### PR TITLE
Fix link to W3C microdata spec (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ THE SOFTWARE.
 
 [html5.vim]:http://www.vim.org/scripts/script.php?script_id=3236
 
-[microdata]:http://dev.w3.org/html5/md/
+[microdata]:http://www.w3.org/TR/microdata/
 [RDFa]:http://www.w3.org/TR/rdfa-syntax/
 [aria]:http://www.w3.org/TR/wai-aria/
 


### PR DESCRIPTION
Very minor change, but the old link lead to a 404.