### PR TITLE
Fixed up the htmlTagName regex to follow custom element naming convention

### DIFF
--- a/syntax/html.vim
+++ b/syntax/html.vim
@@ -66,7 +66,7 @@ syn keyword htmlTagName contained span subset sum tan tanh tendsto times transpo
 syn keyword htmlTagName contained uplimit variance vector vectorproduct xor
 
 " Custom Element
-syn match htmlTagName contained "\<[a-z_]\([a-z0-9_.]\+\)\?\(\-[a-z0-9_.]\+\)\+\>"
+syn match htmlTagName contained "\<[a-z][-.0-9_a-z]*-[-.0-9_a-z]*\>"
 
 " HTML 5 arguments
 " Core Attributes


### PR DESCRIPTION
Fixed the regex to follow the custom element standard taken from:

https://www.w3.org/TR/custom-elements/#prod-potentialcustomelementname

It currently does not support unicode characters. 