### PR TITLE
hack for  embedded javscript indent of pangloss/vim-javascript

### DIFF
--- a/indent/html.vim
+++ b/indent/html.vim
@@ -353,6 +353,7 @@ fun! HtmlIndentGet(lnum)
             if s:jsindent == ''
               return cindent(a:lnum)
             else
+              let b:hi_indent = {'blocklnr': searchpair(js, '', jse, 'nWb')} " hack for 'pangloss/vim-javascript'
               execute 'let ind = ' . s:jsindent
               return ind
             endif


### PR DESCRIPTION
Fix `pangloss/vim-javascript` indent for embedded javascript

[pangloss/vim-javascript](https://github.com/pangloss/vim-javascript) via `b:hi_indent.blocklnr` indent embedded script([this line](https://github.com/pangloss/vim-javascript/blob/c737dd7b900cb2b0a2da96941fd005ea24c52fd0/indent/javascript.vim#L407)), since the `b:hi_indent` variable defined from [vim/runtime/indent/html.vim](https://github.com/vim/vim/blob/3ec574f2b549f456f664f689d6da36dc5719aeb9/runtime/indent/html.vim#L46)