### PR TITLE
Fix shiftwidth=0 being ignored

### DIFF
--- a/indent/html.vim
+++ b/indent/html.vim
@@ -317,6 +317,13 @@ fun! <SID>HtmlIndentSum(lnum, style)
 endfun
 
 fun! HtmlIndentGet(lnum)
+    " Get shiftwidth value.
+    if exists('*shiftwidth')
+        let sw = shiftwidth()
+    else
+        let sw = &sw
+    endif
+
     " Find a non-empty line above the current line.
     let lnum = prevnonblank(a:lnum - 1)
 
@@ -403,7 +410,7 @@ fun! HtmlIndentGet(lnum)
             endif
 
             if 0 == match(getline(a:lnum), '^\s*</')
-                return indent(preline) - (1*&sw)
+                return indent(preline) - (1*sw)
             else
                 return indent(preline)
             endif
@@ -424,7 +431,7 @@ fun! HtmlIndentGet(lnum)
       " let tags_exp = '<\(' . join(tags, '\|') . '\)>'
       " let close_tags_exp = '</\(' . join(tags, '\|') . '\)>'
       " if getline(a:lnum) =~ tags_exp
-        " let block_start = search('^'.repeat(' ', lind + (&sw * ind - 1)).'\S'  , 'bnW')
+        " let block_start = search('^'.repeat(' ', lind + (sw * ind - 1)).'\S'  , 'bnW')
         " let prev_tag = search(tags_exp, 'bW', block_start)
         " let prev_closetag = search(close_tags_exp, 'W', a:lnum)
         " if prev_tag && !prev_closetag
@@ -433,7 +440,7 @@ fun! HtmlIndentGet(lnum)
       " endif
 
       " if getline(a:lnum) =~ '</\w\+>'
-        " let block_start = search('^'.repeat(' ', lind + (&sw * ind - 1)).'\S'  , 'bnW')
+        " let block_start = search('^'.repeat(' ', lind + (sw * ind - 1)).'\S'  , 'bnW')
         " let prev_tag = search(tags_exp, 'bW', block_start)
         " let prev_closetag = search(close_tags_exp, 'W', a:lnum)
         " if prev_tag && !prev_closetag
@@ -446,7 +453,7 @@ fun! HtmlIndentGet(lnum)
         setlocal noic
     endif
 
-    return lind + (&sw * ind)
+    return lind + (sw * ind)
 endfun
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
Quoting from vim's 'options.txt' documentation, `shiftwidth` is:
```
  Number of spaces to use for each step of (auto)indent.  Used for
  |'cindent'|, |>>|, |<<|, etc.
  When zero the 'ts' value will be used.  Use the |shiftwidth()|
  function to get the effective shiftwidth value.
```

Which means if I have `shiftwidth=0` and `tabstop=2` in $MYVIMRC, `shiftwidth` should fallback to being set to 2, and auto indentation using `=` should indent with 2 spaces.

However with the minimal rc below, auto indenting an html file with `gg=G` removes all the indents. (Meaning every line will be at indentation level 0 after `gg=G`.)
```viml
filetype plugin indent on
syntax enable

" Using vim-plug as the plugin manager
call plug#begin('~/.vim/plugged/')
Plug  'othree/html5.vim'
call plug#end()

set shiftwidth=0
sed tabstop=2
```

This PR will fix that up.