### PR TITLE
Added option to allow custom tags without hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Disable WAI-ARIA attribute support:
 
     let g:html5_aria_attributes_complete = 0
 
+Indent custom tags even without hyphens:
+
+    let g:html5_custom_tag_requires_hyphen = 0
+
 ## Change Log
 
 ### Version 0.27

--- a/indent/html.vim
+++ b/indent/html.vim
@@ -54,6 +54,12 @@ endif
 " Allow for line continuation below.
 let s:cpo_save = &cpo
 set cpo-=C
+
+" Option for enabling custom tag without hyphen
+let s:custom_tag_requires_hyphen = 1
+if exists("g:html5_custom_tag_requires_hyphen")
+  let s:custom_tag_requires_hyphen = g:html5_custom_tag_requires_hyphen
+endif
 "}}}
 
 " Check and process settings from b:html_indent and g:html_indent... variables.
@@ -367,6 +373,9 @@ func! s:CheckCustomTag(ctag)
   " Returns 1 if ctag is the tag for a custom element, 0 otherwise.
   " a:ctag can be "tag" or "/tag" or "<!--" or "-->"
   let pattern = '\%\(\w\+-\)\+\w\+'
+  if !s:custom_tag_requires_hyphen
+    let pattern = '\%\(\w\|-\)\+'
+  endif
   if match(a:ctag, pattern) == -1
     return 0
   endif


### PR DESCRIPTION
In Vue/Angular, many developers prefer using `<CamelCase>` to refer to their components instead of `<kebab-case>`. Although `<CamelCase>` is not a custom element according to the html5 specs, I think it wouldn't hurt to add the option? 😄😄😄😄

I have added this option `g:html5_custom_tag_requires_hyphen` which is default to `1` and enforces standard html5. When set to `0`, it will treat `<CamelCase>` as a custom tag too and indent them.

P.S. not sure what is the best description for this new config in `README.md`