### PR TITLE
Add (necessary) boilerplate just like vim/vim

### DIFF
--- a/syntax/html.vim
+++ b/syntax/html.vim
@@ -17,6 +17,17 @@
 " Modified:     htdebeer <H.T.de.Beer@gmail.com>
 " Changes:      add common SVG elements and attributes for inline SVG
 
+" quit when a syntax file was already loaded
+if !exists("main_syntax")
+  if exists("b:current_syntax")
+    finish
+  endif
+  let main_syntax = 'html'
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
 " Patch 7.4.1142
 if has("patch-7.4-1142")
   if has("win32")
@@ -190,3 +201,11 @@ syn keyword htmlArg contained scriptlevel scriptminsize scriptsize scriptsizemul
 syn keyword htmlArg contained stretchy subscriptshift superscriptshift symmetric thickmathspace thinmathspace type valign verythickmathspace verythinmathspace
 syn keyword htmlArg contained veryverythickmathspace veryverythinmathspace voffset width xref
 
+let b:current_syntax = "html"
+
+if main_syntax == 'html'
+  unlet main_syntax
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
This adds boilerplate for syntax file, just like upstream vim/vim: https://github.com/vim/vim/blob/master/runtime/syntax/html.vim

It is necessary in some cases, especially if plugins assume that sourcing html.vim results in the same behavior as vim/vim (for example setting `b:current_syntax` variable). Also it is possible in some cases that syntax/html.vim is loaded multiple times, in which case it should make startup faster.